### PR TITLE
[notification-token] Add OneSignal for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,14 @@
+buildscript {
+    repositories {
+        maven { url 'https://plugins.gradle.org/m2/' } // Gradle Plugin Portal
+    }
+    dependencies {
+        classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.1, 0.99.99]'
+    }
+}
+
+apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'
+
 apply plugin: "com.android.application"
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
@@ -192,6 +203,7 @@ android {
 apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
 
 dependencies {
+    implementation project(':react-native-onesignal')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
+        android:launchMode="singleTop"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>

--- a/android/app/src/main/java/com/dooboolab/hackatalk/MainApplication.java
+++ b/android/app/src/main/java/com/dooboolab/hackatalk/MainApplication.java
@@ -10,6 +10,7 @@ import android.app.Application;
 import android.content.Context;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
+import com.geektime.rnonesignalandroid.ReactNativeOneSignalPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 apply from: '../node_modules/react-native-unimodules/gradle.groovy'
+include ':react-native-onesignal'
+project(':react-native-onesignal').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-onesignal/android')
 includeUnimodulesProjects()
 
 rootProject.name = 'HackaTalk'


### PR DESCRIPTION
## Description

[Add react-native-onesignal for Android](https://documentation.onesignal.com/docs/react-native-sdk-setup#section-android-specific-instructions)

## ScreenShots

<img width="508" alt="noti" src="https://user-images.githubusercontent.com/10173313/75510751-5ab51100-5a2f-11ea-88a3-dad19318715b.png">
<img width="508" alt="foreground" src="https://user-images.githubusercontent.com/10173313/75510756-5c7ed480-5a2f-11ea-9b7b-545a3c8079b7.png">



## Related Issues

on 'add notification token' part of [#98](https://github.com/dooboolab/hackatalk-mobile/issues/98)

## Tests

not yet

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk-mobile/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
